### PR TITLE
Update 012-jdbc-mysql.jsp

### DIFF
--- a/java/vulns/src/main/webapp/012-jdbc-mysql.jsp
+++ b/java/vulns/src/main/webapp/012-jdbc-mysql.jsp
@@ -10,7 +10,7 @@
         ResultSet rset = null; 
         try {
             Class.forName("com.mysql.jdbc.Driver");
-            conn = DriverManager.getConnection("jdbc:mysql://localhost:3306/test", "test", "test");  
+            conn = DriverManager.getConnection("jdbc:mysql://localhost:3306/test?serverTimezone=UTC", "test", "test");  
             stmt = conn.createStatement();
             rset = stmt.executeQuery ("SELECT * FROM vuln WHERE id = " + id);
             return (formatResult(rset));


### PR DESCRIPTION
解决以下报错："java.sql.SQLException: The server time zone value 'EDT' is unrecognized or represents more than one time zone. You must configure either the server or JDBC driver (via the 'serverTimezone' configuration property) to use a more specific time zone value if you want to utilize time zone support. "